### PR TITLE
fix: add directory to assets in wrangler

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,7 +18,8 @@ upstream_protocol = "https"
 enabled = true
 head_sampling_rate = 1
 
-[directory]
+[assets]
+directory = "./public"
 binding = "Assets"
 not_found_handling = "none"
 html_handling = "auto-trailing-slash"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,7 +18,7 @@ upstream_protocol = "https"
 enabled = true
 head_sampling_rate = 1
 
-[assets]
+[directory]
 binding = "Assets"
 not_found_handling = "none"
 html_handling = "auto-trailing-slash"


### PR DESCRIPTION
## Summary

Fixing vitest for unit tests after the big merge

## Tests

`npm test` should work now

## Additional information

would adding this line cause any unintended future issues down the line?
If so, could we change the above line to only work when testing locally?
