### PR TITLE
Feature: trim inputs and lowercase emails

### DIFF
--- a/api/api_tests/01_auth_sign-up.hurl
+++ b/api/api_tests/01_auth_sign-up.hurl
@@ -163,7 +163,7 @@ Content-Type: application/json
 	"password":"ExtraSpaces911!@#$"
 }
 
-HTTP 422
+HTTP 200
 
 
 # Sign-up password allows password utilizing space characters wihin allowed characters but not outside

--- a/api/api_tests/sign-up/01-email-lower-case.hurl
+++ b/api/api_tests/sign-up/01-email-lower-case.hurl
@@ -1,0 +1,12 @@
+# Emails should be converted to lower case
+POST {{host}}/api/auth/sign-up
+
+Content-Type: application/json
+
+{
+	"name":"CaSe InSeNsItIvE",
+	"email":"CaSe-InSeNsItIvE@example.com",
+	"password":"FruityThisIs911!@#"
+}
+
+HTTP 200

--- a/api/src/routes/auth/validation.ts
+++ b/api/src/routes/auth/validation.ts
@@ -21,9 +21,9 @@ export const AccessSchema = IdAndSchemaVersionSchema.merge(z.object({
 		.describe("The user's password, hashed and salted."),
 	email: z
 		.string()
-		.email()
 		.trim()
 		.toLowerCase()
+		.email()
 		.describe("The user's email. It is the same as the email in the profile table."),
 	insertedAt: z
 		.string()

--- a/api/src/routes/auth/validation.ts
+++ b/api/src/routes/auth/validation.ts
@@ -47,10 +47,10 @@ export type Access = z.infer<typeof AccessSchema>;
 export const SignInSchema = z.object({
 	email: z
 		.string({ required_error: 'Email is required' })
-		.email('Invalid Email')
 		.trim()
 		.toLowerCase()
-		.min(1, 'Email must be at least one character long'),
+		.min(1, 'Email must be at least one character long')
+		.email('Invalid Email'),
 	password: z
 		.string()
 		.trim()

--- a/api/src/routes/auth/validation.ts
+++ b/api/src/routes/auth/validation.ts
@@ -17,10 +17,13 @@ export const AccessSchema = IdAndSchemaVersionSchema.merge(z.object({
 	accessLevel: AccessLevelSchema,
 	password: z
 		.string()
+		.trim()
 		.describe("The user's password, hashed and salted."),
 	email: z
 		.string()
 		.email()
+		.trim()
+		.toLowerCase()
 		.describe("The user's email. It is the same as the email in the profile table."),
 	insertedAt: z
 		.string()
@@ -34,6 +37,7 @@ export const AccessSchema = IdAndSchemaVersionSchema.merge(z.object({
 		.describe('The date when the entity was added to the database.'),
 	deletedreason: z
 		.string()
+		.trim()
 		.optional()
 		.describe('The reason why a profile is deleted. It is kept as extra information for admins.')
 }));
@@ -43,10 +47,13 @@ export type Access = z.infer<typeof AccessSchema>;
 export const SignInSchema = z.object({
 	email: z
 		.string({ required_error: 'Email is required' })
-		.min(1, 'Email must be at least one character long')
-		.email('Invalid Email'),
+		.email('Invalid Email')
+		.trim()
+		.toLowerCase()
+		.min(1, 'Email must be at least one character long'),
 	password: z
 		.string()
+		.trim()
 		.min(1, 'Password must be at least one character long')
 });
 
@@ -55,13 +62,17 @@ export type SignInData = z.infer<typeof SignInSchema>;
 export const SignUpSchema = z.object({
 	name: z
 		.string({ required_error: 'Name is required' })
+		.trim()
 		.min(1, 'Name must be at least one character long'),
 	email: z
 		.string({ required_error: 'Email is required' })
+		.trim()
+		.toLowerCase()
 		.min(1, 'Email must be at least one character long')
 		.email('Invalid Email'),
 	password: z
 		.string()
+		.trim()
 		.min(1, 'Password must be at least one character long')
 });
 

--- a/api/src/routes/event-log/validation.ts
+++ b/api/src/routes/event-log/validation.ts
@@ -22,6 +22,7 @@ export const EventLogSchema = IdAndSchemaVersionSchema
 		subjectSource: LogItemSourceSchema,
 		verb: z
 			.string()
+			.trim()
 			.describe(''),
 		object: z
 			.string()

--- a/api/src/routes/profile/validation.ts
+++ b/api/src/routes/profile/validation.ts
@@ -12,6 +12,8 @@ export const ProfileSchema = BaseDbEntitySchema.merge(z.object({
 	email: z
 		.string()
 		.email('Invalid Email.')
+		.trim()
+		.toLowerCase()
 		.describe('The email used for this profile, it must be unique on the database.'),
 	name: z
 		.string()
@@ -20,6 +22,7 @@ export const ProfileSchema = BaseDbEntitySchema.merge(z.object({
 		.describe('The name this person would like to be refered to.'),
 	description: z
 		.string()
+		.trim()
 		.optional()
 		.describe('A description for this person, may be written in markdown.'),
 	isBasedOnGTA: z
@@ -30,10 +33,12 @@ export const ProfileSchema = BaseDbEntitySchema.merge(z.object({
 		.describe('A flag indicating if the user is available to join local/in-person events.'),
 	pronouns: z
 		.string()
+		.trim()
 		.optional()
 		.describe('The pronouns the person identifies with.'),
 	birthday: z
 		.string()
+		.trim()
 		.optional()
 		.refine(
 			(data) => data ? /^\d{2}-\d{2}$/iu.test(data) : true,
@@ -103,6 +108,7 @@ export const ProfileSkillSchema = z.object({
 		.describe('The profile id.'),
 	skill: z
 		.string()
+		.trim()
 		.describe('The link name.')
 });
 

--- a/api/src/routes/profile/validation.ts
+++ b/api/src/routes/profile/validation.ts
@@ -11,9 +11,9 @@ export type SocialMediaPlatforms = z.infer<typeof PlatformEnum>;
 export const ProfileSchema = BaseDbEntitySchema.merge(z.object({
 	email: z
 		.string()
-		.email('Invalid Email.')
 		.trim()
 		.toLowerCase()
+		.email('Invalid Email.')
 		.describe('The email used for this profile, it must be unique on the database.'),
 	name: z
 		.string()

--- a/api/src/routes/team-members/validation.ts
+++ b/api/src/routes/team-members/validation.ts
@@ -9,6 +9,7 @@ export const TeamMembershipSchema = BaseDbEntitySchema.merge(z.object({
 		.describe("The role's name."),
 	description: z
 		.string()
+		.trim()
 		.optional()
 		.describe('A description for the role. It may include markdown content.'),
 	teamId: z

--- a/api/src/routes/team/validation.ts
+++ b/api/src/routes/team/validation.ts
@@ -9,6 +9,7 @@ export const TeamSchema = BaseDbEntitySchema.merge(z.object({
 		.describe("The team's name."),
 	description: z
 		.string()
+		.trim()
 		.optional()
 		.describe('A description for the team. It may include markdown content.')
 }));


### PR DESCRIPTION
## Summary

Trim all user inputs that are "open strings". Types that are things like a UUID or a Date are not trimmed as they already should be provided trimmed or will error out.

All emails will be cast to lowercase.

## Tests

Added a test for signup with mixed case email.

## Additional information

Closes: #97 #124 
