### PR TITLE
Units conversion details added on style contribution docs #251

### DIFF
--- a/docs/contributing-guide/coding-standard/06-style-structure.md
+++ b/docs/contributing-guide/coding-standard/06-style-structure.md
@@ -1,0 +1,5 @@
+# Style Structure
+
+## Use of rem Instead of px
+
+Using rem units is generally preferred over px because it improves accessibility. With rem, users can adjust font sizes through their browser settings, ensuring a more inclusive experience.


### PR DESCRIPTION
06-style-structure.md has been added under the docs/contributing-guide/coding-standard folder. It will provide details on why to use rem instead of px.